### PR TITLE
Add WebM audio support by converting to WAV for transcription

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv
 python-magic
 slowapi
 librosa
+pydub


### PR DESCRIPTION
## Summary by Sourcery

Add support for WebM audio files by converting them to WAV format for transcription and update file type validation to include WebM.

New Features:
- Add support for transcribing audio from WebM files by converting them to WAV format before processing.

Enhancements:
- Improve file type validation to include WebM format for audio transcription.