### PR TITLE
Revamp README and add CPU-only Docker deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 venv/
 __pycache__/
 .aider*

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN python -m pip install --upgrade pip
 # Install the required packages
 RUN pip install --no-cache-dir -r requirements.txt
 
+#Pip Install the required packages for the GPU
+RUN torch --index-url https://download.pytorch.org/whl/cu121
+
 # Install the required packages for python magic
 RUN apt-get update && apt-get install -y \
     libmagic1 \
@@ -32,4 +35,3 @@ COPY ./.env ./.env
 
 # Expose the port the app runs on
 EXPOSE 2224
-        

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,35 @@
+# Use the official Python image
+FROM python:3.10-slim
+
+# Set the working directory
+WORKDIR /app
+
+#setup dir we will need and set non root user perms
+RUN mkdir -p /.cache && chown -R 1000:1000 /.cache
+
+# Copy the Speech2text server code into the container
+COPY ./requirements.txt .
+
+#Upgrade pip
+RUN python -m pip install --upgrade pip
+
+# Install the required packages
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install the required packages for python magic
+RUN apt-get update && apt-get install -y \
+    libmagic1 \
+    && apt-get clean
+
+
+# Install ffmpeg required for whisper transcription
+RUN apt-get install ffmpeg -y
+
+# copy the rest of the directory into the container
+COPY ./server.py .
+COPY ./utils.py .
+COPY ./.env ./.env
+
+# Expose the port the app runs on
+EXPOSE 2224
+        

--- a/README.md
+++ b/README.md
@@ -1,84 +1,98 @@
-# speech2text-container
+# FreeScribe Speech-to-Text Server
 
-Containerized solution for AI speech-to-text that can run locally
+This software is released under the AGPL-3.0 license  
+Copyright (c) 2023-2024 Braedon Hendy
 
-# Prerequisites
+Part of the ClinicianFOCUS initiative, a collaboration with Conestoga College Institute of Applied Learning and Technology's CNERG+ applied research project.
 
-Docker and Docker-compose installed on your system.
+## Overview
 
-# Build and run
+FreeScribe is an open-source speech-to-text server that utilizes OpenAI's Whisper model for audio transcription. It provides a robust API endpoint for converting audio files to text, with support for various audio formats including MP3, WAV, and WebM.
 
-1. Install
+## Features
+
+- Fast audio transcription using Whisper AI
+- Support for multiple audio formats (MP3, WAV, WebM)
+- Rate limiting protection
+- API key authentication
+- GPU support for faster processing
+- Docker containerization
+- Reverse proxy setup with Caddy
+
+## Prerequisites
+
+- Docker and Docker Compose
+- NVIDIA GPU (optional, for GPU acceleration)
+- NVIDIA Container Toolkit (if using GPU)
+
+## Configuration
+
+### Environment Variables
+
+Create a `.env` file with the following variables:
+
+```env
+WHISPER_MODEL=medium    # Whisper model size (tiny, base, small, medium, large) (Default: medium)
+WHISPER_PORT=2224      # Port for the service (Default: 2224)
+WHISPER_HOST=0.0.0.0   # Host address (Default: 0.0.0.0)
+UVICORN_WORKERS=1      # Number of Uvicorn workers (Default: 1)
+```
+
+## Deployment Options
+
+### CPU-Only Deployment
 
 ```bash
-git clone https://github.com/ClinicianFOCUS/speech2text-container.git
+docker-compose -f docker-compose.cpu.yml up --build
 ```
 
-2. Navigate into the directory
+### GPU-Enabled Deployment
 
 ```bash
-cd speech2text-container
+docker-compose up --build
 ```
 
-- **Recommended Step:** Set a API key in the .env file. this will be the key used to access the API. If this step is skipped the container wil generate a random key for you upon each start.
+## Container Structure
 
-3. Build and run the docker images using docker-compose
+The application consists of two main containers:
 
-```bash
-docker-compose up -d --build
-```
+1. **speech-container**
 
-# Usage
+   - Runs the FastAPI application
+   - Handles audio transcription
+   - Configurable for CPU or GPU usage
 
-Send a Request: Send audio data to the exposed endpoint on http://localhost:2224/whisperaudio
+2. **caddy**
+   - Reverse proxy
+   - Handles HTTPS termination
+   - Manages incoming traffic
 
-The following environment variables can be customized to control the behavior of the `speech-container` service:
+## API Usage
 
-- `WHISPER_MODEL`: The Whisper model to use (default: `medium`).
-- `WHISPER_PORT`: The port to expose the service (default: `2224`).
-- `WHISPER_HOST`: The host to bind the service (default: `0.0.0.0`).
-- `UVICORN_WORKERS`: Number of Uvicorn workers (default: `1`).
-- `USE_GPU`: Whether to use the GPU for inference. Default: `"True"`.
+### Endpoint: POST /whisperaudio
 
-**Windows Example**
+Transcribe an audio file to text.
 
-```Bash
-$env:WHISPER_MODEL="large"; $env:WHISPER_PORT="2224"; $env:WHISPER_HOST="127.0.0.1"; docker-compose up -d --build
-```
+**Request:**
 
-**Linux Example**:
+- Method: POST
+- Content-Type: multipart/form-data
+- Authorization: Bearer <api_key>
+- Body: audio file (MP3, WAV, or WebM)
 
-NOTE: Not tested in a linux environment
-
-```bash
-WHISPER_MODEL=large WHISPER_PORT=2224 WHISPER_HOST=127.0.0.1 docker-compose up -d --build
-
-```
-
-This will start the transcription service with the `large` Whisper model on port `2224`, accessible only from `127.0.0.1`.
-
-# Authentication
-
-On server start up you will receive a api key in the console. This key changes on each start up of the software.
-
-You can set your own API key in the .env. This will be your authentication key when launched in the container.
-
-# Example request
-
-```bash
-   curl -X POST "http://localhost:2224/whisperaudio" \
-        -H "Authorization: Bearer <api_key>" \
-        -F "file=@/path/to/audiofile.wav"
-```
-
-# Example response
+**Response:**
 
 ```json
 {
-  "text": "Transcribed text here"
+  "text": "Transcribed text from the audio file."
 }
 ```
 
-# License
+## Rate Limiting
 
-This project is licensed under the AGPL-3.0 License. See the LICENSE file for details.
+- Default rate limit: 1 request per second
+- Rate limit errors return 429 status code
+
+## License
+
+This project is licensed under the AGPL-3.0 License - see the LICENSE file for details.

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,0 +1,41 @@
+# Docker Compose configuration file for setting up a speech transcription service
+
+services:
+  # Service definition for the speech transcription container
+  speech-container:
+    # Build configuration for the container
+    build:
+      context: . # The build context is the current directory
+      dockerfile: Dockerfile.cpu # The Dockerfile to use for building the image
+    container_name: speech-container # Name of the container
+    user: "1000:1000" # Set the user to '1000:1000'
+    environment:
+      - WHISPER_MODEL=${WHISPER_MODEL:-medium} # Set the WHISPER_MODEL environment variable to 'tiny'
+      - WHISPER_PORT=2224 # Set the PORT environment variable to '2224'
+      - WHISPER_HOST=${WHISPER_HOST:-0.0.0.0} # Set the HOST environment variable to '
+      - UVICORN_WORKERS=${UVICORN_WORKERS:-1} # Set the UVICORN_WORKERS environment variable to '1'
+      - USE_GPU=False # Set the USE_GPU environment variable to '1'
+    networks:
+      - speech-network # Connect the container to the 'speech-network' network
+    command: python -m uvicorn server:app --host ${WHISPER_HOST:-0.0.0.0} --port 2224 --workers ${UVICORN_WORKERS:-1} # Command to run when the container starts
+    restart: on-failure # Restart policy on failure
+
+  # Service definition for the Caddy reverse proxy
+  caddy:
+    container_name: caddy # Name of the container
+    user: "1000:1000" # Set the user to '1000:1000'
+    build:
+      context: .
+      dockerfile: Dockerfile.caddy
+    ports:
+      - ${WHISPER_PORT:-2224}:2224 # Map port the provided port to the whisper container
+    networks:
+      - speech-network # Connect the container to the 'speech-network' network
+    depends_on:
+      - speech-container # Ensure the 'speech-container' service starts before this one
+    restart: on-failure # Restart policy on failure
+
+# Network configuration
+networks:
+  speech-network:
+    driver: bridge # Use the bridge network driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - WHISPER_PORT=2224 # Set the PORT environment variable to '2224'
       - WHISPER_HOST=${WHISPER_HOST:-0.0.0.0} # Set the HOST environment variable to '
       - UVICORN_WORKERS=${UVICORN_WORKERS:-1} # Set the UVICORN_WORKERS environment variable to '1'
-      - USE_GPU=${USE_GPU:-True} # Set the USE_GPU environment variable to '1'
+      - USE_GPU=True # Set the USE_GPU environment variable to '1'
     networks:
       - speech-network # Connect the container to the 'speech-network' network
     command: python -m uvicorn server:app --host ${WHISPER_HOST:-0.0.0.0} --port 2224 --workers ${UVICORN_WORKERS:-1} # Command to run when the container starts

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ python-magic
 slowapi
 librosa
 pydub
-torch --index-url https://download.pytorch.org/whl/cu121

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-magic
 slowapi
 librosa
 pydub
+torch --index-url https://download.pytorch.org/whl/cu121


### PR DESCRIPTION
## Summary by Sourcery

Revamp the README to enhance documentation and introduce a CPU-only Docker deployment option for the FreeScribe Speech-to-Text Server.

New Features:
- Introduce a CPU-only Docker deployment option for the speech-to-text service.

Enhancements:
- Revamp the README to provide a more comprehensive overview of the FreeScribe Speech-to-Text Server, including features, prerequisites, configuration, and deployment options.

Build:
- Add a new Dockerfile.cpu for building a CPU-only version of the Docker image.
- Update the Dockerfile to include GPU-specific package installations.

Documentation:
- Update the README to reflect the new project name, features, and deployment instructions.