### PR TITLE
configure caddy for remote connection

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,7 @@
+{
+    debug
+    default_sni default_sni
+}
 localhost:2224 {
     tls internal
     reverse_proxy speech-container:2224
@@ -7,7 +11,15 @@ localhost:2224 {
     }
 }
 
-127.0.0.1:2224 {
+:2224 {
     tls internal
     reverse_proxy speech-container:2224
+
+    request_body {
+        max_size 3000MB  # Set the maximum file upload size to 50MB
+    }
+}
+
+default_sni {
+    tls internal
 }


### PR DESCRIPTION
**Issue**: #27

## Summary by Sourcery

Deployment:
- Configure Caddy server to allow remote connections by updating the Caddyfile.