### PR TITLE
Increase rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 venv/
 __pycache__/
 .aider*
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use the official Python image
 FROM python:3.10-slim
 
+# Create a group with GID 1000 and a user with UID 1000
+RUN addgroup --gid 1000 appgroup && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" appuser
+
 # Set the working directory
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apt-get install ffmpeg -y
 # copy the rest of the directory into the container
 COPY ./server.py .
 COPY ./utils.py .
-COPY ./.env ./.env
 
 # Expose the port the app runs on
 EXPOSE 2224

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,6 +1,9 @@
 # Use the official Python image
 FROM python:3.10-slim
 
+# Create a group with GID 1000 and a user with UID 1000
+RUN addgroup --gid 1000 appgroup && adduser --uid 1000 --gid 1000 --disabled-password --gecos "" appuser
+
 # Set the working directory
 WORKDIR /app
 

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -28,7 +28,6 @@ RUN apt-get install ffmpeg -y
 # copy the rest of the directory into the container
 COPY ./server.py .
 COPY ./utils.py .
-COPY ./.env ./.env
 
 # Expose the port the app runs on
 EXPOSE 2224

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -8,7 +8,7 @@ services:
       context: . # The build context is the current directory
       dockerfile: Dockerfile.cpu # The Dockerfile to use for building the image
     container_name: speech-container # Name of the container
-    user: "1000:1000" # Set the user to '1000:1000'
+    user: "appuser:appgroup" # Set the user to '1000:1000'
     environment:
       - PYTHONUNBUFFERED=1 # Enable unbuffered Python output
       - WHISPER_MODEL=${WHISPER_MODEL:-medium} # Set the WHISPER_MODEL environment variable to 'tiny'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       context: . # The build context is the current directory
       dockerfile: Dockerfile # The Dockerfile to use for building the image
     container_name: speech-container # Name of the container
-    user: "1000:1000" # Set the user to '1000:1000'
+    user: "appuser:appgroup" # Set the user to '1000:1000'
     environment:
       - PYTHONUNBUFFERED=1 # Enable unbuffered Python output
       - WHISPER_MODEL=${WHISPER_MODEL:-medium} # Set the WHISPER_MODEL environment variable to 'tiny'

--- a/server.py
+++ b/server.py
@@ -134,7 +134,7 @@ def normalize_audio(file_content: bytes, file_type: str) -> tuple[bytes, str]:
 
 # Define the endpoint for transcribing audio files
 @app.post("/whisperaudio")
-@limiter.limit("1/second")
+@limiter.limit("10/second")
 async def transcribe_audio(
     request: Request, audio: UploadFile = File(...), api_key: str = Security(get_api_key)
 ):


### PR DESCRIPTION
### Issue
- #30 
- #31

## Summary by Sourcery

Increase the rate limit for the /whisperaudio endpoint to handle more requests per second and update the Dockerfile to exclude the .env file from being copied into the Docker image.

Enhancements:
- Increase the rate limit for the /whisperaudio endpoint from 1 request per second to 10 requests per second.

Build:
- Remove the copying of the .env file into the Docker image in the Dockerfile.