### PR TITLE
build with no cache

### DIFF
--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: . # The build context is the current directory
       dockerfile: Dockerfile.cpu # The Dockerfile to use for building the image
+      no_cache: true # Disable caching during the build process
     container_name: speech-container # Name of the container
     user: "appuser:appgroup" # Set the user to '1000:1000'
     environment:
@@ -29,6 +30,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.caddy
+      no_cache: true # Disable caching during the build process
     ports:
       - ${WHISPER_PORT:-2224}:2224 # Map port the provided port to the whisper container
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     build:
       context: . # The build context is the current directory
       dockerfile: Dockerfile # The Dockerfile to use for building the image
+      no_cache: true # Disable caching during the build process
     container_name: speech-container # Name of the container
     user: "appuser:appgroup" # Set the user to '1000:1000'
     environment:
@@ -40,6 +41,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.caddy
+      no_cache: true # Disable caching during the build process
     ports:
       - ${WHISPER_PORT:-2224}:2224 # Map port the provided port to the whisper container
     networks:


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Disable caching during the Docker image build process in docker-compose configurations.